### PR TITLE
Enable and fix package:pedantic lints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: true
 
 dart:
   - dev
-  - stable
+  - 2.0.0
 
 dart_task:
   - test: -p chrome,vm
@@ -16,7 +16,8 @@ matrix:
     - dart: dev
       dart_task: dartfmt
     - dart: dev
-      dart_task: analyzer
+      dart_task:
+        dartanalizer: --fatal-warnings --fatal-infos .
 
 # Only building master means that we don't run two builds for each pull request.
 branches:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.1.6-dev
+
 ## 1.1.5
 
 * Set max SDK version to `<3.0.0`.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,6 @@
+include: package:pedantic/analysis_options.yaml
+analyzer:
+  strong-mode:
+    implicit-casts: false
+  language:
+    strict-raw-types: true

--- a/lib/source_map_stack_trace.dart
+++ b/lib/source_map_stack_trace.dart
@@ -20,17 +20,17 @@ import 'package:stack_trace/stack_trace.dart';
 /// It can be a [String] or a [Uri]. If it's passed, stack frames from the SDK
 /// will have `dart:` URLs.
 ///
-/// [packageRoot] is deprecated and shouldn't be used in new code. This throws
-/// an [ArgumentError] if [packageRoot] and [packageResolver] are both passed.
+/// `packageRoot` is deprecated and shouldn't be used in new code. This throws
+/// an [ArgumentError] if `packageRoot` and [packageResolver] are both passed.
 StackTrace mapStackTrace(Mapping sourceMap, StackTrace stackTrace,
     {bool minified = false,
     SyncPackageResolver packageResolver,
     sdkRoot,
-    @Deprecated("Use the packageResolver parameter instead.") packageRoot}) {
+    @Deprecated('Use the packageResolver parameter instead.') packageRoot}) {
   if (packageRoot != null) {
     if (packageResolver != null) {
       throw ArgumentError(
-          "packageResolver and packageRoot may not both be passed.");
+          'packageResolver and packageRoot may not both be passed.');
     }
 
     packageResolver = SyncPackageResolver.root(packageRoot);
@@ -49,7 +49,7 @@ StackTrace mapStackTrace(Mapping sourceMap, StackTrace stackTrace,
     throw ArgumentError('sdkRoot must be a String or a Uri, was "$sdkRoot".');
   }
 
-  var sdkLib = sdkRoot == null ? null : "$sdkRoot/lib";
+  var sdkLib = sdkRoot == null ? null : '$sdkRoot/lib';
 
   var trace = Trace.from(stackTrace);
   return Trace(trace.frames.map((frame) {
@@ -58,7 +58,7 @@ StackTrace mapStackTrace(Mapping sourceMap, StackTrace stackTrace,
     if (frame.line == null) return null;
 
     // If there's no column, try using the first column of the line.
-    var column = frame.column == null ? 0 : frame.column;
+    var column = frame.column ?? 0;
 
     // Subtract 1 because stack traces use 1-indexed lines and columns and
     // source maps uses 0-indexed.
@@ -71,11 +71,11 @@ StackTrace mapStackTrace(Mapping sourceMap, StackTrace stackTrace,
 
     var sourceUrl = span.sourceUrl.toString();
     if (sdkRoot != null && p.url.isWithin(sdkLib, sourceUrl)) {
-      sourceUrl = "dart:" + p.url.relative(sourceUrl, from: sdkLib);
+      sourceUrl = 'dart:' + p.url.relative(sourceUrl, from: sdkLib);
     } else if (packageResolver != null) {
       if (packageResolver.packageRoot != null &&
           p.url.isWithin(packageResolver.packageRoot.toString(), sourceUrl)) {
-        sourceUrl = "package:" +
+        sourceUrl = 'package:' +
             p.url.relative(sourceUrl,
                 from: packageResolver.packageRoot.toString());
       } else if (packageResolver.packageConfigMap != null) {
@@ -84,7 +84,7 @@ StackTrace mapStackTrace(Mapping sourceMap, StackTrace stackTrace,
           if (!p.url.isWithin(packageUrl, sourceUrl)) continue;
 
           sourceUrl =
-              "package:$package/" + p.url.relative(sourceUrl, from: packageUrl);
+              'package:$package/' + p.url.relative(sourceUrl, from: packageUrl);
           break;
         }
       }
@@ -107,26 +107,26 @@ StackTrace mapStackTrace(Mapping sourceMap, StackTrace stackTrace,
 String _prettifyMember(String member) {
   return member
       // Get rid of the noise that Firefox sometimes adds.
-      .replaceAll(RegExp(r"/?<$"), "")
+      .replaceAll(RegExp(r'/?<$'), '')
       // Get rid of arity indicators and named arguments.
-      .replaceAll(RegExp(r"\$\d+(\$[a-zA-Z_0-9]+)*$"), "")
+      .replaceAll(RegExp(r'\$\d+(\$[a-zA-Z_0-9]+)*$'), '')
       // Convert closures to <fn>.
       .replaceAllMapped(
-          RegExp(r"(_+)closure\d*\.call$"),
+          RegExp(r'(_+)closure\d*\.call$'),
           // The number of underscores before "closure" indicates how nested it
           // is.
-          (match) => ".<fn>" * match[1].length)
+          (match) => '.<fn>' * match[1].length)
       // Get rid of explicitly-generated calls.
-      .replaceAll(RegExp(r"\.call$"), "")
+      .replaceAll(RegExp(r'\.call$'), '')
       // Get rid of the top-level method prefix.
-      .replaceAll(RegExp(r"^dart\."), "")
+      .replaceAll(RegExp(r'^dart\.'), '')
       // Get rid of library namespaces.
-      .replaceAll(RegExp(r"[a-zA-Z_0-9]+\$"), "")
+      .replaceAll(RegExp(r'[a-zA-Z_0-9]+\$'), '')
       // Get rid of the static method prefix. The class name also exists in the
       // invocation, so we're not getting rid of any information.
-      .replaceAll(RegExp(r"^[a-zA-Z_0-9]+.(static|dart)."), "")
+      .replaceAll(RegExp(r'^[a-zA-Z_0-9]+.(static|dart).'), '')
       // Convert underscores after identifiers to dots. This runs the risk of
       // incorrectly converting members that contain underscores, but those are
       // contrary to the style guide anyway.
-      .replaceAllMapped(RegExp(r"([a-zA-Z0-9]+)_"), (match) => match[1] + ".");
+      .replaceAllMapped(RegExp(r'([a-zA-Z0-9]+)_'), (match) => match[1] + '.');
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/source_map_stack_trace
 
 environment:
-  sdk: '>=1.8.0 <3.0.0'
+  sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
   package_resolver: ^1.0.0
@@ -16,3 +16,4 @@ dependencies:
 
 dev_dependencies:
   test: '>=0.12.0 <2.0.0'
+  pedantic: ^1.0.0

--- a/test/source_map_stack_trace_test.dart
+++ b/test/source_map_stack_trace_test.dart
@@ -14,17 +14,17 @@ import 'package:test/test.dart';
 final _simpleMapping = parseJson((SourceMapBuilder()
       ..addSpan(
           SourceMapSpan.identifier(
-              SourceLocation(1, line: 1, column: 3, sourceUrl: "foo.dart"),
-              "qux"),
+              SourceLocation(1, line: 1, column: 3, sourceUrl: 'foo.dart'),
+              'qux'),
           SourceSpan(SourceLocation(8, line: 5, column: 0),
-              SourceLocation(18, line: 15, column: 0), "\n" * 10)))
-    .build("foo.dart.js.map"));
+              SourceLocation(18, line: 15, column: 0), '\n' * 10)))
+    .build('foo.dart.js.map'));
 
 void main() {
-  test("maps a JS line and column to a Dart line and span", () {
-    var trace = Trace.parse("foo.dart.js 10:11  foo");
+  test('maps a JS line and column to a Dart line and span', () {
+    var trace = Trace.parse('foo.dart.js 10:11  foo');
     var frame = _mapTrace(_simpleMapping, trace).frames.first;
-    expect(frame.uri, equals(Uri.parse("foo.dart")));
+    expect(frame.uri, equals(Uri.parse('foo.dart')));
 
     // These are +1 because stack_trace is 1-based whereas source_span is
     // 0-basd.
@@ -32,249 +32,249 @@ void main() {
     expect(frame.column, equals(4));
   });
 
-  test("ignores JS frames without line info", () {
-    var trace = Trace.parse("""
+  test('ignores JS frames without line info', () {
+    var trace = Trace.parse('''
 foo.dart.js 10:11  foo
 foo.dart.js        bar
 foo.dart.js 10:11  baz
-""");
+''');
     var frames = _mapTrace(_simpleMapping, trace).frames;
 
     expect(frames.length, equals(2));
-    expect(frames.first.member, equals("foo"));
-    expect(frames.last.member, equals("baz"));
+    expect(frames.first.member, equals('foo'));
+    expect(frames.last.member, equals('baz'));
   });
 
-  test("ignores JS frames without corresponding spans", () {
-    var trace = Trace.parse("""
+  test('ignores JS frames without corresponding spans', () {
+    var trace = Trace.parse('''
 foo.dart.js 10:11  foo
 foo.dart.js 1:1   bar
 foo.dart.js 10:11  baz
-""");
+''');
 
     var frames = _mapTrace(_simpleMapping, trace).frames;
 
     expect(frames.length, equals(2));
-    expect(frames.first.member, equals("foo"));
-    expect(frames.last.member, equals("baz"));
+    expect(frames.first.member, equals('foo'));
+    expect(frames.last.member, equals('baz'));
   });
 
-  test("include frames from JS files not covered by the source map bundle", () {
-    var trace = Trace.parse("""
+  test('include frames from JS files not covered by the source map bundle', () {
+    var trace = Trace.parse('''
 foo.dart.js 10:11  foo
 jquery.js 10:1  foo
 bar.dart.js 10:11  foo
-""");
+''');
     var builder = SourceMapBuilder()
       ..addSpan(
           SourceMapSpan.identifier(
               SourceLocation(1,
-                  line: 1, column: 3, sourceUrl: "packages/foo/foo.dart"),
-              "qux"),
+                  line: 1, column: 3, sourceUrl: 'packages/foo/foo.dart'),
+              'qux'),
           SourceSpan(SourceLocation(8, line: 5, column: 0),
-              SourceLocation(12, line: 9, column: 1), "\n" * 4));
-    var sourceMapJson1 = builder.build("foo.dart.js.map");
-    sourceMapJson1['file'] = "foo.dart.js";
+              SourceLocation(12, line: 9, column: 1), '\n' * 4));
+    var sourceMapJson1 = builder.build('foo.dart.js.map');
+    sourceMapJson1['file'] = 'foo.dart.js';
 
     builder = SourceMapBuilder()
       ..addSpan(
           SourceMapSpan.identifier(
               SourceLocation(1,
-                  line: 1, column: 3, sourceUrl: "packages/bar/bar.dart"),
-              "qux"),
+                  line: 1, column: 3, sourceUrl: 'packages/bar/bar.dart'),
+              'qux'),
           SourceSpan(SourceLocation(8, line: 5, column: 0),
-              SourceLocation(12, line: 9, column: 1), "\n" * 4));
-    var sourceMapJson2 = builder.build("bar.dart.js.map");
-    sourceMapJson2['file'] = "bar.dart.js";
+              SourceLocation(12, line: 9, column: 1), '\n' * 4));
+    var sourceMapJson2 = builder.build('bar.dart.js.map');
+    sourceMapJson2['file'] = 'bar.dart.js';
 
     var bundle = [sourceMapJson1, sourceMapJson2];
     var mapping = parseJsonExtended(bundle);
     var frames = _mapTrace(mapping, trace,
-            packageResolver: SyncPackageResolver.root("packages/"))
+            packageResolver: SyncPackageResolver.root('packages/'))
         .frames;
 
     expect(frames.length, equals(3));
 
     var frame = frames[0];
-    expect(frame.uri, equals(Uri.parse("package:foo/foo.dart")));
+    expect(frame.uri, equals(Uri.parse('package:foo/foo.dart')));
     expect(frame.line, equals(2));
     expect(frame.column, equals(4));
 
     frame = frames[1];
-    expect(p.basename(frame.uri.toString()), equals("jquery.js"));
+    expect(p.basename(frame.uri.toString()), equals('jquery.js'));
     expect(frame.line, equals(10));
 
     frame = frames[2];
-    expect(frame.uri, equals(Uri.parse("package:bar/bar.dart")));
+    expect(frame.uri, equals(Uri.parse('package:bar/bar.dart')));
     expect(frame.line, equals(2));
     expect(frame.column, equals(4));
   });
 
-  test("falls back to column 0 for unlisted column", () {
-    var trace = Trace.parse("foo.dart.js 10  foo");
+  test('falls back to column 0 for unlisted column', () {
+    var trace = Trace.parse('foo.dart.js 10  foo');
     var builder = SourceMapBuilder()
       ..addSpan(
           SourceMapSpan.identifier(
-              SourceLocation(1, line: 1, column: 3, sourceUrl: "foo.dart"),
-              "qux"),
+              SourceLocation(1, line: 1, column: 3, sourceUrl: 'foo.dart'),
+              'qux'),
           SourceSpan(SourceLocation(8, line: 5, column: 0),
-              SourceLocation(12, line: 9, column: 1), "\n" * 4));
+              SourceLocation(12, line: 9, column: 1), '\n' * 4));
 
-    var mapping = parseJson(builder.build("foo.dart.js.map"));
+    var mapping = parseJson(builder.build('foo.dart.js.map'));
     var frame = _mapTrace(mapping, trace).frames.first;
-    expect(frame.uri, equals(Uri.parse("foo.dart")));
+    expect(frame.uri, equals(Uri.parse('foo.dart')));
     expect(frame.line, equals(2));
     expect(frame.column, equals(4));
   });
 
-  test("uses package: URIs for frames within packageRoot", () {
-    var trace = Trace.parse("foo.dart.js 10  foo");
+  test('uses package: URIs for frames within packageRoot', () {
+    var trace = Trace.parse('foo.dart.js 10  foo');
     var builder = SourceMapBuilder()
       ..addSpan(
           SourceMapSpan.identifier(
               SourceLocation(1,
-                  line: 1, column: 3, sourceUrl: "packages/foo/foo.dart"),
-              "qux"),
+                  line: 1, column: 3, sourceUrl: 'packages/foo/foo.dart'),
+              'qux'),
           SourceSpan(SourceLocation(8, line: 5, column: 0),
-              SourceLocation(12, line: 9, column: 1), "\n" * 4));
+              SourceLocation(12, line: 9, column: 1), '\n' * 4));
 
-    var mapping = parseJson(builder.build("foo.dart.js.map"));
+    var mapping = parseJson(builder.build('foo.dart.js.map'));
     var frame =
-        _mapTrace(mapping, trace, packageRoot: "packages/").frames.first;
-    expect(frame.uri, equals(Uri.parse("package:foo/foo.dart")));
+        _mapTrace(mapping, trace, packageRoot: 'packages/').frames.first;
+    expect(frame.uri, equals(Uri.parse('package:foo/foo.dart')));
     expect(frame.line, equals(2));
     expect(frame.column, equals(4));
   });
 
-  test("uses package: URIs for frames within packageResolver.packageRoot", () {
-    var trace = Trace.parse("foo.dart.js 10  foo");
+  test('uses package: URIs for frames within packageResolver.packageRoot', () {
+    var trace = Trace.parse('foo.dart.js 10  foo');
     var builder = SourceMapBuilder()
       ..addSpan(
           SourceMapSpan.identifier(
               SourceLocation(1,
-                  line: 1, column: 3, sourceUrl: "packages/foo/foo.dart"),
-              "qux"),
+                  line: 1, column: 3, sourceUrl: 'packages/foo/foo.dart'),
+              'qux'),
           SourceSpan(SourceLocation(8, line: 5, column: 0),
-              SourceLocation(12, line: 9, column: 1), "\n" * 4));
+              SourceLocation(12, line: 9, column: 1), '\n' * 4));
 
-    var mapping = parseJson(builder.build("foo.dart.js.map"));
+    var mapping = parseJson(builder.build('foo.dart.js.map'));
     var mappedTrace = _mapTrace(mapping, trace,
-        packageResolver: SyncPackageResolver.root("packages/"));
+        packageResolver: SyncPackageResolver.root('packages/'));
     var frame = mappedTrace.frames.first;
-    expect(frame.uri, equals(Uri.parse("package:foo/foo.dart")));
+    expect(frame.uri, equals(Uri.parse('package:foo/foo.dart')));
     expect(frame.line, equals(2));
     expect(frame.column, equals(4));
   });
 
-  test("uses package: URIs for frames within a packageResolver.packageMap URL",
+  test('uses package: URIs for frames within a packageResolver.packageMap URL',
       () {
-    var trace = Trace.parse("foo.dart.js 10  foo");
+    var trace = Trace.parse('foo.dart.js 10  foo');
     var builder = SourceMapBuilder()
       ..addSpan(
           SourceMapSpan.identifier(
               SourceLocation(1,
-                  line: 1, column: 3, sourceUrl: "packages/foo/foo.dart"),
-              "qux"),
+                  line: 1, column: 3, sourceUrl: 'packages/foo/foo.dart'),
+              'qux'),
           SourceSpan(SourceLocation(8, line: 5, column: 0),
-              SourceLocation(12, line: 9, column: 1), "\n" * 4));
+              SourceLocation(12, line: 9, column: 1), '\n' * 4));
 
-    var mapping = parseJson(builder.build("foo.dart.js.map"));
+    var mapping = parseJson(builder.build('foo.dart.js.map'));
     var mappedTrace = _mapTrace(mapping, trace,
         packageResolver:
-            SyncPackageResolver.config({"foo": Uri.parse("packages/foo")}));
+            SyncPackageResolver.config({'foo': Uri.parse('packages/foo')}));
     var frame = mappedTrace.frames.first;
-    expect(frame.uri, equals(Uri.parse("package:foo/foo.dart")));
+    expect(frame.uri, equals(Uri.parse('package:foo/foo.dart')));
     expect(frame.line, equals(2));
     expect(frame.column, equals(4));
   });
 
-  test("uses dart: URIs for frames within sdkRoot", () {
-    var trace = Trace.parse("foo.dart.js 10  foo");
+  test('uses dart: URIs for frames within sdkRoot', () {
+    var trace = Trace.parse('foo.dart.js 10  foo');
     var builder = SourceMapBuilder()
       ..addSpan(
           SourceMapSpan.identifier(
               SourceLocation(1,
-                  line: 1, column: 3, sourceUrl: "sdk/lib/async/foo.dart"),
-              "qux"),
+                  line: 1, column: 3, sourceUrl: 'sdk/lib/async/foo.dart'),
+              'qux'),
           SourceSpan(SourceLocation(8, line: 5, column: 0),
-              SourceLocation(12, line: 9, column: 1), "\n" * 4));
+              SourceLocation(12, line: 9, column: 1), '\n' * 4));
 
-    var mapping = parseJson(builder.build("foo.dart.js.map"));
-    var frame = _mapTrace(mapping, trace, sdkRoot: "sdk/").frames.first;
-    expect(frame.uri, equals(Uri.parse("dart:async/foo.dart")));
+    var mapping = parseJson(builder.build('foo.dart.js.map'));
+    var frame = _mapTrace(mapping, trace, sdkRoot: 'sdk/').frames.first;
+    expect(frame.uri, equals(Uri.parse('dart:async/foo.dart')));
     expect(frame.line, equals(2));
     expect(frame.column, equals(4));
   });
 
-  test("converts a stack chain", () {
+  test('converts a stack chain', () {
     var trace = Chain([
-      Trace.parse("foo.dart.js 10:11  foo"),
-      Trace.parse("foo.dart.js 10:11  bar")
+      Trace.parse('foo.dart.js 10:11  foo'),
+      Trace.parse('foo.dart.js 10:11  bar')
     ]);
     var traces = _mapChain(_simpleMapping, trace).traces;
 
     var frame = traces.first.frames.single;
-    expect(frame.uri, equals(Uri.parse("foo.dart")));
-    expect(frame.member, equals("foo"));
+    expect(frame.uri, equals(Uri.parse('foo.dart')));
+    expect(frame.member, equals('foo'));
     expect(frame.line, equals(2));
     expect(frame.column, equals(4));
 
     frame = traces.last.frames.single;
-    expect(frame.uri, equals(Uri.parse("foo.dart")));
-    expect(frame.member, equals("bar"));
+    expect(frame.uri, equals(Uri.parse('foo.dart')));
+    expect(frame.member, equals('bar'));
     expect(frame.line, equals(2));
     expect(frame.column, equals(4));
   });
 
-  group("cleans up", () {
-    test("Firefox junk", () {
-      expect(_prettify("foo/<"), equals("foo"));
-      expect(_prettify("foo<"), equals("foo"));
+  group('cleans up', () {
+    test('Firefox junk', () {
+      expect(_prettify('foo/<'), equals('foo'));
+      expect(_prettify('foo<'), equals('foo'));
     });
 
-    test("arity indicators", () {
-      expect(_prettify(r"foo$1"), equals("foo"));
-      expect(_prettify(r"foo$1234"), equals("foo"));
+    test('arity indicators', () {
+      expect(_prettify(r'foo$1'), equals('foo'));
+      expect(_prettify(r'foo$1234'), equals('foo'));
     });
 
-    test("named arguments", () {
-      expect(_prettify(r"foo$1$bar"), equals("foo"));
-      expect(_prettify(r"foo$123$bar$bang$qux"), equals("foo"));
+    test('named arguments', () {
+      expect(_prettify(r'foo$1$bar'), equals('foo'));
+      expect(_prettify(r'foo$123$bar$bang$qux'), equals('foo'));
     });
 
-    test("closures", () {
-      expect(_prettify("foo_closure.call"), equals("foo.<fn>"));
+    test('closures', () {
+      expect(_prettify('foo_closure.call'), equals('foo.<fn>'));
     });
 
-    test("nested closures", () {
-      expect(_prettify("foo__closure.call"), equals("foo.<fn>.<fn>"));
+    test('nested closures', () {
+      expect(_prettify('foo__closure.call'), equals('foo.<fn>.<fn>'));
       expect(
-          _prettify("foo____closure.call"), equals("foo.<fn>.<fn>.<fn>.<fn>"));
+          _prettify('foo____closure.call'), equals('foo.<fn>.<fn>.<fn>.<fn>'));
     });
 
-    test(".call", () {
-      expect(_prettify("foo.call"), equals("foo"));
+    test('.call', () {
+      expect(_prettify('foo.call'), equals('foo'));
     });
 
-    test("top-level functions", () {
-      expect(_prettify("dart.foo"), equals("foo"));
+    test('top-level functions', () {
+      expect(_prettify('dart.foo'), equals('foo'));
     });
 
-    test("library namespaces", () {
-      expect(_prettify(r"my_library$foo"), equals("foo"));
+    test('library namespaces', () {
+      expect(_prettify(r'my_library$foo'), equals('foo'));
     });
 
-    test("static methods", () {
-      expect(_prettify(r"Foo.static.foo"), equals("foo"));
+    test('static methods', () {
+      expect(_prettify(r'Foo.static.foo'), equals('foo'));
     });
 
-    test("instance methods", () {
-      expect(_prettify(r"Foo_bar__baz"), equals("Foo.bar._baz"));
+    test('instance methods', () {
+      expect(_prettify(r'Foo_bar__baz'), equals('Foo.bar._baz'));
     });
 
-    test("lots of stuff", () {
-      expect(_prettify(r"lib$Foo.static.lib$Foo_closure.call$0/<"),
-          equals("Foo.<fn>"));
+    test('lots of stuff', () {
+      expect(_prettify(r'lib$Foo.static.lib$Foo_closure.call$0/<'),
+          equals('Foo.<fn>'));
     });
   });
 }
@@ -290,6 +290,7 @@ Trace _mapTrace(Mapping sourceMap, StackTrace stackTrace,
       minified: minified,
       packageResolver: packageResolver,
       sdkRoot: sdkRoot,
+      // ignore: deprecated_member_use_from_same_package
       packageRoot: packageRoot));
 }
 
@@ -304,11 +305,12 @@ Chain _mapChain(Mapping sourceMap, StackTrace stackTrace,
       minified: minified,
       packageResolver: packageResolver,
       sdkRoot: sdkRoot,
+      // ignore: deprecated_member_use_from_same_package
       packageRoot: packageRoot));
 }
 
 /// Runs the mapper's prettification logic on [member] and returns the result.
 String _prettify(String member) {
-  var trace = Trace([Frame(Uri.parse("foo.dart.js"), 10, 11, member)]);
+  var trace = Trace([Frame(Uri.parse('foo.dart.js'), 10, 11, member)]);
   return _mapTrace(_simpleMapping, trace).frames.first.member;
 }


### PR DESCRIPTION
Disable implicit casts, enable strict raw types. These were already
clean.

Enable`package:pedantic` lints. Clean up violations of:
- prefer_if_null_operators
- prefer_single_quotes

Ignore existing violations of deprecated_member_use_from_same_package.
Change some comment references to avoid the deprecated member, it will
be removed soon.

Bump the min SDK to `2.0.0` and ensure tests run on the oldest supported
SDK instead of only stable and dev.

Fail travis for info level output from analyzer.