### PR TITLE
Remove support for legacy arguments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: true
 
 dart:
   - dev
-  - 2.0.0
+  - 2.4.0
 
 dart_task:
   - test: -p chrome,vm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 1.1.6-dev
+## 2.0.0-dev
+
+* **Breaking** The `sdkRoot` argument must be an `Uri`. Use `Uri.parse` for use
+  cases previously passing a `String`.
+* **Breaking** The deprecated `packageRoot` argument has been removed.
 
 ## 1.1.5
 

--- a/lib/source_map_stack_trace.dart
+++ b/lib/source_map_stack_trace.dart
@@ -19,10 +19,7 @@ import 'package:stack_trace/stack_trace.dart';
 /// [sdkRoot] is the URI surfaced in the stack traces for SDK libraries.
 /// If it's passed, stack frames from the SDK will have `dart:` URLs.
 StackTrace mapStackTrace(Mapping sourceMap, StackTrace stackTrace,
-    {bool minified = false,
-    SyncPackageResolver packageResolver,
-    Uri sdkRoot
-    }) {
+    {bool minified = false, SyncPackageResolver packageResolver, Uri sdkRoot}) {
   if (stackTrace is Chain) {
     return Chain(stackTrace.traces.map((trace) {
       return Trace.from(mapStackTrace(sourceMap, trace,

--- a/lib/source_map_stack_trace.dart
+++ b/lib/source_map_stack_trace.dart
@@ -16,26 +16,13 @@ import 'package:stack_trace/stack_trace.dart';
 /// If [packageResolver] is passed, it's used to reconstruct `package:` URIs for
 /// stack frames that come from packages.
 ///
-/// [sdkRoot] is the URI (usually a `file:` URI) for the SDK containing dart2js.
-/// It can be a [String] or a [Uri]. If it's passed, stack frames from the SDK
-/// will have `dart:` URLs.
-///
-/// `packageRoot` is deprecated and shouldn't be used in new code. This throws
-/// an [ArgumentError] if `packageRoot` and [packageResolver] are both passed.
+/// [sdkRoot] is the URI surfaced in the stack traces for SDK libraries.
+/// If it's passed, stack frames from the SDK will have `dart:` URLs.
 StackTrace mapStackTrace(Mapping sourceMap, StackTrace stackTrace,
     {bool minified = false,
     SyncPackageResolver packageResolver,
-    sdkRoot,
-    @Deprecated('Use the packageResolver parameter instead.') packageRoot}) {
-  if (packageRoot != null) {
-    if (packageResolver != null) {
-      throw ArgumentError(
-          'packageResolver and packageRoot may not both be passed.');
-    }
-
-    packageResolver = SyncPackageResolver.root(packageRoot);
-  }
-
+    Uri sdkRoot
+    }) {
   if (stackTrace is Chain) {
     return Chain(stackTrace.traces.map((trace) {
       return Trace.from(mapStackTrace(sourceMap, trace,
@@ -43,10 +30,6 @@ StackTrace mapStackTrace(Mapping sourceMap, StackTrace stackTrace,
           packageResolver: packageResolver,
           sdkRoot: sdkRoot));
     }));
-  }
-
-  if (sdkRoot != null && sdkRoot is! String && sdkRoot is! Uri) {
-    throw ArgumentError('sdkRoot must be a String or a Uri, was "$sdkRoot".');
   }
 
   var sdkLib = sdkRoot == null ? null : '$sdkRoot/lib';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: source_map_stack_trace
-version: 1.1.6-dev
+version: 2.0.0-dev
 
 description: A package for applying source maps to stack traces.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/source_map_stack_trace
 
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.4.0 <3.0.0'
 
 dependencies:
   package_resolver: ^1.0.0
@@ -15,5 +15,8 @@ dependencies:
   source_maps: ^0.10.2
 
 dev_dependencies:
-  test: '>=0.12.0 <2.0.0'
+  test: ^1.12.0
   pedantic: ^1.0.0
+
+dependency_overrides:
+  test_core: ^0.3.0

--- a/test/source_map_stack_trace_test.dart
+++ b/test/source_map_stack_trace_test.dart
@@ -127,25 +127,6 @@ bar.dart.js 10:11  foo
     expect(frame.column, equals(4));
   });
 
-  test('uses package: URIs for frames within packageRoot', () {
-    var trace = Trace.parse('foo.dart.js 10  foo');
-    var builder = SourceMapBuilder()
-      ..addSpan(
-          SourceMapSpan.identifier(
-              SourceLocation(1,
-                  line: 1, column: 3, sourceUrl: 'packages/foo/foo.dart'),
-              'qux'),
-          SourceSpan(SourceLocation(8, line: 5, column: 0),
-              SourceLocation(12, line: 9, column: 1), '\n' * 4));
-
-    var mapping = parseJson(builder.build('foo.dart.js.map'));
-    var frame =
-        _mapTrace(mapping, trace, packageRoot: 'packages/').frames.first;
-    expect(frame.uri, equals(Uri.parse('package:foo/foo.dart')));
-    expect(frame.line, equals(2));
-    expect(frame.column, equals(4));
-  });
-
   test('uses package: URIs for frames within packageResolver.packageRoot', () {
     var trace = Trace.parse('foo.dart.js 10  foo');
     var builder = SourceMapBuilder()
@@ -200,7 +181,8 @@ bar.dart.js 10:11  foo
               SourceLocation(12, line: 9, column: 1), '\n' * 4));
 
     var mapping = parseJson(builder.build('foo.dart.js.map'));
-    var frame = _mapTrace(mapping, trace, sdkRoot: 'sdk/').frames.first;
+    var frame =
+        _mapTrace(mapping, trace, sdkRoot: Uri.parse('sdk/')).frames.first;
     expect(frame.uri, equals(Uri.parse('dart:async/foo.dart')));
     expect(frame.line, equals(2));
     expect(frame.column, equals(4));
@@ -282,31 +264,17 @@ bar.dart.js 10:11  foo
 /// Like [mapStackTrace], but is guaranteed to return a [Trace] so it can be
 /// inspected.
 Trace _mapTrace(Mapping sourceMap, StackTrace stackTrace,
-    {bool minified = false,
-    SyncPackageResolver packageResolver,
-    sdkRoot,
-    packageRoot}) {
+    {bool minified = false, SyncPackageResolver packageResolver, Uri sdkRoot}) {
   return Trace.from(mapStackTrace(sourceMap, stackTrace,
-      minified: minified,
-      packageResolver: packageResolver,
-      sdkRoot: sdkRoot,
-      // ignore: deprecated_member_use_from_same_package
-      packageRoot: packageRoot));
+      minified: minified, packageResolver: packageResolver, sdkRoot: sdkRoot));
 }
 
 /// Like [mapStackTrace], but is guaranteed to return a [Chain] so it can be
 /// inspected.
 Chain _mapChain(Mapping sourceMap, StackTrace stackTrace,
-    {bool minified = false,
-    SyncPackageResolver packageResolver,
-    sdkRoot,
-    packageRoot}) {
+    {bool minified = false, SyncPackageResolver packageResolver, Uri sdkRoot}) {
   return Chain.forTrace(mapStackTrace(sourceMap, stackTrace,
-      minified: minified,
-      packageResolver: packageResolver,
-      sdkRoot: sdkRoot,
-      // ignore: deprecated_member_use_from_same_package
-      packageRoot: packageRoot));
+      minified: minified, packageResolver: packageResolver, sdkRoot: sdkRoot));
 }
 
 /// Runs the mapper's prettification logic on [member] and returns the result.


### PR DESCRIPTION
Closes #8

Remove deprecated `packageRoot` argument, nothing should be using this.

Change `sdkUri` to be statically a `Uri` for more type safety. We only
ever really need the String representation, but by enforcing the type we
keep usage more on the rails. The only usage in `package:test_core` is
passing a Uri, and other uses can easily wrap with `Uri.parse`.

Bump the minimum SDK to `2.4.0`. Not version of `package:test` will
support this package with a lower SDK bound, so it is not useful to
claim support for earlier SDks that we can't test on.