### PR TITLE
drop package_resolver dependency and remove packageRoot support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: true
 
 dart:
   - dev
-  - 2.1.0
+  - 2.7.0
 
 dart_task:
   - test: -p chrome,vm

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: true
 
 dart:
   - dev
-  - 2.0.0
+  - 2.1.0
 
 dart_task:
   - test: -p chrome,vm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
-## 1.1.6-dev
+## 2.0.0
+
+### Breaking Changes
+
+- Removed dependency on `package_resolver` and changed the apis to accept a
+  `Map<String, Uri>` which maps package names to the base uri to resolve the
+  `package:` uris for those packages.
+- Dropped support for the `packageRoot` argument which has been deprecated
+  for a while.
 
 ## 1.1.5
 

--- a/lib/source_map_stack_trace.dart
+++ b/lib/source_map_stack_trace.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:package_resolver/package_resolver.dart';
 import 'package:path/path.dart' as p;
 import 'package:source_maps/source_maps.dart';
 import 'package:stack_trace/stack_trace.dart';
@@ -13,35 +12,19 @@ import 'package:stack_trace/stack_trace.dart';
 /// [minified] indicates whether or not the dart2js code was minified. If it
 /// hasn't, this tries to clean up the stack frame member names.
 ///
-/// If [packageResolver] is passed, it's used to reconstruct `package:` URIs for
-/// stack frames that come from packages.
+/// The [packageMap] maps package names to the base uri used to resolve the
+/// `package:` uris for those packages. It is used to  it's used to reconstruct
+/// `package:` URIs for stack frames that come from packages.
 ///
 /// [sdkRoot] is the URI (usually a `file:` URI) for the SDK containing dart2js.
 /// It can be a [String] or a [Uri]. If it's passed, stack frames from the SDK
 /// will have `dart:` URLs.
-///
-/// `packageRoot` is deprecated and shouldn't be used in new code. This throws
-/// an [ArgumentError] if `packageRoot` and [packageResolver] are both passed.
 StackTrace mapStackTrace(Mapping sourceMap, StackTrace stackTrace,
-    {bool minified = false,
-    SyncPackageResolver packageResolver,
-    sdkRoot,
-    @Deprecated('Use the packageResolver parameter instead.') packageRoot}) {
-  if (packageRoot != null) {
-    if (packageResolver != null) {
-      throw ArgumentError(
-          'packageResolver and packageRoot may not both be passed.');
-    }
-
-    packageResolver = SyncPackageResolver.root(packageRoot);
-  }
-
+    {bool minified = false, Map<String, Uri> packageMap, sdkRoot}) {
   if (stackTrace is Chain) {
     return Chain(stackTrace.traces.map((trace) {
       return Trace.from(mapStackTrace(sourceMap, trace,
-          minified: minified,
-          packageResolver: packageResolver,
-          sdkRoot: sdkRoot));
+          minified: minified, packageMap: packageMap, sdkRoot: sdkRoot));
     }));
   }
 
@@ -72,21 +55,14 @@ StackTrace mapStackTrace(Mapping sourceMap, StackTrace stackTrace,
     var sourceUrl = span.sourceUrl.toString();
     if (sdkRoot != null && p.url.isWithin(sdkLib, sourceUrl)) {
       sourceUrl = 'dart:' + p.url.relative(sourceUrl, from: sdkLib);
-    } else if (packageResolver != null) {
-      if (packageResolver.packageRoot != null &&
-          p.url.isWithin(packageResolver.packageRoot.toString(), sourceUrl)) {
-        sourceUrl = 'package:' +
-            p.url.relative(sourceUrl,
-                from: packageResolver.packageRoot.toString());
-      } else if (packageResolver.packageConfigMap != null) {
-        for (var package in packageResolver.packageConfigMap.keys) {
-          var packageUrl = packageResolver.packageConfigMap[package].toString();
-          if (!p.url.isWithin(packageUrl, sourceUrl)) continue;
+    } else if (packageMap != null) {
+      for (var package in packageMap.keys) {
+        var packageUrl = packageMap[package].toString();
+        if (!p.url.isWithin(packageUrl, sourceUrl)) continue;
 
-          sourceUrl =
-              'package:$package/' + p.url.relative(sourceUrl, from: packageUrl);
-          break;
-        }
+        sourceUrl =
+            'package:$package/' + p.url.relative(sourceUrl, from: packageUrl);
+        break;
       }
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,8 +29,5 @@ dependency_overrides:
       url: https://github.com/dart-lang/test.git
       ref: drop-package-resolver
       path: pkgs/test
-  package_config:
-    git:
-      url: https://github.com/dart-lang/package_config.git
-      ref: '1.9'
+  package_config: ^1.9.1
     

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,6 @@
 name: source_map_stack_trace
 version: 2.0.0
-
 description: A package for applying source maps to stack traces.
-author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/source_map_stack_trace
 
 environment:
@@ -14,6 +12,7 @@ dependencies:
   source_maps: ^0.10.2
 
 dev_dependencies:
+  source_span: ^1.6.0
   test: ^1.12.0
   pedantic: ^1.0.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: source_map_stack_trace
-version: 1.1.6-dev
+version: 2.0.0
 
 description: A package for applying source maps to stack traces.
 author: Dart Team <misc@dartlang.org>
@@ -9,7 +9,6 @@ environment:
   sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
-  package_resolver: ^1.0.0
   path: ^1.0.0
   stack_trace: ^1.0.0
   source_maps: ^0.10.2
@@ -17,3 +16,21 @@ dependencies:
 dev_dependencies:
   test: '>=0.12.0 <2.0.0'
   pedantic: ^1.0.0
+
+dependency_overrides:
+  # Required to get a valid pub solve until package:test updates
+  test_core:
+    git:
+      url: https://github.com/dart-lang/test.git
+      ref: drop-package-resolver
+      path: pkgs/test_core
+  test:
+    git:
+      url: https://github.com/dart-lang/test.git
+      ref: drop-package-resolver
+      path: pkgs/test
+  package_config:
+    git:
+      url: https://github.com/dart-lang/package_config.git
+      ref: '1.9'
+    

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/source_map_stack_trace
 
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.1.0 <3.0.0'
 
 dependencies:
   path: ^1.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/source_map_stack_trace
 
 environment:
-  sdk: '>=2.1.0 <3.0.0'
+  sdk: '>=2.7.0 <3.0.0'
 
 dependencies:
   path: ^1.0.0

--- a/test/source_map_stack_trace_test.dart
+++ b/test/source_map_stack_trace_test.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:package_resolver/package_resolver.dart';
 import 'package:path/path.dart' as p;
 import 'package:source_maps/source_maps.dart';
 import 'package:source_span/source_span.dart';
@@ -19,6 +18,11 @@ final _simpleMapping = parseJson((SourceMapBuilder()
           SourceSpan(SourceLocation(8, line: 5, column: 0),
               SourceLocation(18, line: 15, column: 0), '\n' * 10)))
     .build('foo.dart.js.map'));
+
+final _packageMap = {
+  'bar': Uri.parse('packages/bar'),
+  'foo': Uri.parse('packages/foo'),
+};
 
 void main() {
   test('maps a JS line and column to a Dart line and span', () {
@@ -89,9 +93,7 @@ bar.dart.js 10:11  foo
 
     var bundle = [sourceMapJson1, sourceMapJson2];
     var mapping = parseJsonExtended(bundle);
-    var frames = _mapTrace(mapping, trace,
-            packageResolver: SyncPackageResolver.root('packages/'))
-        .frames;
+    var frames = _mapTrace(mapping, trace, packageMap: _packageMap).frames;
 
     expect(frames.length, equals(3));
 
@@ -127,45 +129,6 @@ bar.dart.js 10:11  foo
     expect(frame.column, equals(4));
   });
 
-  test('uses package: URIs for frames within packageRoot', () {
-    var trace = Trace.parse('foo.dart.js 10  foo');
-    var builder = SourceMapBuilder()
-      ..addSpan(
-          SourceMapSpan.identifier(
-              SourceLocation(1,
-                  line: 1, column: 3, sourceUrl: 'packages/foo/foo.dart'),
-              'qux'),
-          SourceSpan(SourceLocation(8, line: 5, column: 0),
-              SourceLocation(12, line: 9, column: 1), '\n' * 4));
-
-    var mapping = parseJson(builder.build('foo.dart.js.map'));
-    var frame =
-        _mapTrace(mapping, trace, packageRoot: 'packages/').frames.first;
-    expect(frame.uri, equals(Uri.parse('package:foo/foo.dart')));
-    expect(frame.line, equals(2));
-    expect(frame.column, equals(4));
-  });
-
-  test('uses package: URIs for frames within packageResolver.packageRoot', () {
-    var trace = Trace.parse('foo.dart.js 10  foo');
-    var builder = SourceMapBuilder()
-      ..addSpan(
-          SourceMapSpan.identifier(
-              SourceLocation(1,
-                  line: 1, column: 3, sourceUrl: 'packages/foo/foo.dart'),
-              'qux'),
-          SourceSpan(SourceLocation(8, line: 5, column: 0),
-              SourceLocation(12, line: 9, column: 1), '\n' * 4));
-
-    var mapping = parseJson(builder.build('foo.dart.js.map'));
-    var mappedTrace = _mapTrace(mapping, trace,
-        packageResolver: SyncPackageResolver.root('packages/'));
-    var frame = mappedTrace.frames.first;
-    expect(frame.uri, equals(Uri.parse('package:foo/foo.dart')));
-    expect(frame.line, equals(2));
-    expect(frame.column, equals(4));
-  });
-
   test('uses package: URIs for frames within a packageResolver.packageMap URL',
       () {
     var trace = Trace.parse('foo.dart.js 10  foo');
@@ -179,9 +142,7 @@ bar.dart.js 10:11  foo
               SourceLocation(12, line: 9, column: 1), '\n' * 4));
 
     var mapping = parseJson(builder.build('foo.dart.js.map'));
-    var mappedTrace = _mapTrace(mapping, trace,
-        packageResolver:
-            SyncPackageResolver.config({'foo': Uri.parse('packages/foo')}));
+    var mappedTrace = _mapTrace(mapping, trace, packageMap: _packageMap);
     var frame = mappedTrace.frames.first;
     expect(frame.uri, equals(Uri.parse('package:foo/foo.dart')));
     expect(frame.line, equals(2));
@@ -282,31 +243,17 @@ bar.dart.js 10:11  foo
 /// Like [mapStackTrace], but is guaranteed to return a [Trace] so it can be
 /// inspected.
 Trace _mapTrace(Mapping sourceMap, StackTrace stackTrace,
-    {bool minified = false,
-    SyncPackageResolver packageResolver,
-    sdkRoot,
-    packageRoot}) {
+    {bool minified = false, Map<String, Uri> packageMap, sdkRoot}) {
   return Trace.from(mapStackTrace(sourceMap, stackTrace,
-      minified: minified,
-      packageResolver: packageResolver,
-      sdkRoot: sdkRoot,
-      // ignore: deprecated_member_use_from_same_package
-      packageRoot: packageRoot));
+      minified: minified, packageMap: packageMap, sdkRoot: sdkRoot));
 }
 
 /// Like [mapStackTrace], but is guaranteed to return a [Chain] so it can be
 /// inspected.
 Chain _mapChain(Mapping sourceMap, StackTrace stackTrace,
-    {bool minified = false,
-    SyncPackageResolver packageResolver,
-    sdkRoot,
-    packageRoot}) {
+    {bool minified = false, Map<String, Uri> packageMap, sdkRoot}) {
   return Chain.forTrace(mapStackTrace(sourceMap, stackTrace,
-      minified: minified,
-      packageResolver: packageResolver,
-      sdkRoot: sdkRoot,
-      // ignore: deprecated_member_use_from_same_package
-      packageRoot: packageRoot));
+      minified: minified, packageMap: packageMap, sdkRoot: sdkRoot));
 }
 
 /// Runs the mapper's prettification logic on [member] and returns the result.


### PR DESCRIPTION
Closes https://github.com/dart-lang/source_map_stack_trace/issues/10

Will wait to merge until I confirm the overridden branches from package:test are also passing.