### PR TITLE
Prepare for the 2.11 dev SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0-nullsafety.2
+
+* Allow 2.10 stable and 2.11.0 dev SDK versions.
+
 ## 2.1.0-nullsafety.1
 
 * Update source_maps constraint.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: source_map_stack_trace
-version: 2.1.0-nullsafety.1
+version: 2.1.0-nullsafety.2
 description: A package for applying source maps to stack traces.
 homepage: https://github.com/dart-lang/source_map_stack_trace
 
 environment:
   # This must remain a tight constraint until nnbd is stable
-  sdk: '>=2.10.0-0 <2.10.0'
+  sdk: '>=2.10.0-0 <2.11.0'
 
 dependencies:
   path: '>=1.8.0-nullsafety <1.8.0'


### PR DESCRIPTION
Bump the upper bound to allow 2.10 stable and 2.11.0 dev SDK versions.