### PR TITLE
allow the 2.12 prerelease sdks and prep to publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0-nullsafety.3
+
+* Allow prerelease versions of the 2.12 sdk.
+
 ## 2.1.0-nullsafety.2
 
 * Allow 2.10 stable and 2.11.0 dev SDK versions.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: source_map_stack_trace
-version: 2.1.0-nullsafety.2
+version: 2.1.0-nullsafety.3
 description: A package for applying source maps to stack traces.
 homepage: https://github.com/dart-lang/source_map_stack_trace
 
 environment:
   # This must remain a tight constraint until nnbd is stable
-  sdk: '>=2.10.0-0 <2.11.0'
+  sdk: '>=2.10.0-0 <2.12.0'
 
 dependencies:
   path: '>=1.8.0-nullsafety <1.8.0'
@@ -13,60 +13,6 @@ dependencies:
   source_maps: '>=0.10.10-nullsafety <0.10.10'
 
 dev_dependencies:
-  source_span: ^1.6.0
-  test: ^1.12.0
-  pedantic: ^1.0.0
-
-dependency_overrides:
-  async:
-    git: git://github.com/dart-lang/async.git
-  boolean_selector:
-    git: git://github.com/dart-lang/boolean_selector.git
-  charcode:
-    git: git://github.com/dart-lang/charcode.git
-  collection:
-    git: git://github.com/dart-lang/collection.git
-  js:
-    git:
-      url: git://github.com/dart-lang/sdk.git
-      path: pkg/js
-      ref: 2-10-pkgs
-  matcher:
-    git: git://github.com/dart-lang/matcher.git
-  meta:
-    git:
-      url: git://github.com/dart-lang/sdk.git
-      path: pkg/meta
-      ref: 2-10-pkgs
-  path:
-    git: git://github.com/dart-lang/path.git
-  pedantic:
-    git: git://github.com/dart-lang/pedantic.git
-  pool:
-    git: git://github.com/dart-lang/pool.git
-  source_maps:
-    git: git://github.com/dart-lang/source_maps.git
-  source_span:
-    git: git://github.com/dart-lang/source_span.git
-  stack_trace:
-    git: git://github.com/dart-lang/stack_trace.git
-  stream_channel:
-    git: git://github.com/dart-lang/stream_channel.git
-  string_scanner:
-    git: git://github.com/dart-lang/string_scanner.git
-  term_glyph:
-    git: git://github.com/dart-lang/term_glyph.git
-  test_api:
-    git:
-      url: git://github.com/dart-lang/test.git
-      path: pkgs/test_api
-  test_core:
-    git:
-      url: git://github.com/dart-lang/test.git
-      path: pkgs/test_core
-  test:
-    git:
-      url: git://github.com/dart-lang/test.git
-      path: pkgs/test
-  typed_data:
-    git: git://github.com/dart-lang/typed_data.git
+  source_span: ^1.8.0-nullsafety
+  test: ^1.16.0-nullsafety
+  pedantic: ^1.10.0-nullsafety


### PR DESCRIPTION
- also removes git overrides in favor of published versions